### PR TITLE
Auto-drop in a random column if the current is full

### DIFF
--- a/src/main/java/com/megabyte6/connect4/controller/GameController.java
+++ b/src/main/java/com/megabyte6/connect4/controller/GameController.java
@@ -289,7 +289,7 @@ public class GameController implements Controller {
             SceneManager.popup("Please return to the current move.");
             return;
         }
-        
+
         final int row = game.findNextFreeRow(column);
 
         // Column is full.
@@ -390,7 +390,6 @@ public class GameController implements Controller {
                 }
                 marker.layoutXProperty().bind(markerBindings[column]);
                 placePiece(column);
-                updateMarkerBindings();
             } else {
                 swapTurns();
             }

--- a/src/main/java/com/megabyte6/connect4/controller/GameController.java
+++ b/src/main/java/com/megabyte6/connect4/controller/GameController.java
@@ -191,7 +191,7 @@ public class GameController implements Controller {
 
         gameBoard.setOnMouseMoved(event -> updateMarkerPosition(event.getX()));
 
-        root.setOnMouseClicked(event -> placePiece());
+        root.setOnMouseClicked(event -> placePiece(game.getSelectedColumn()));
 
         root.setOnKeyPressed(event -> {
             if (event.isShortcutDown())
@@ -282,15 +282,14 @@ public class GameController implements Controller {
         marker.layoutXProperty().bind(markerBindings[game.getSelectedColumn()]);
     }
 
-    private void placePiece() {
+    private void placePiece(int column) {
         if (game.isGameOver())
             return;
         if (game.isPaused() && !game.isGameOver()) {
             SceneManager.popup("Please return to the current move.");
             return;
         }
-
-        final int column = game.getSelectedColumn();
+        
         final int row = game.findNextFreeRow(column);
 
         // Column is full.
@@ -384,7 +383,14 @@ public class GameController implements Controller {
         timer.setOnUpdate(() -> timerLabel.setText("Time left: " + timer.getFormattedTime()));
         timer.setOnTimeout(() -> {
             if (App.getSettings().isTimerAutoDrop()) {
-                placePiece();
+                final List<Integer> freeColumns = game.findFreeColumns();
+                int column = game.getSelectedColumn();
+                if (!freeColumns.contains(column)) {
+                    column = freeColumns.get((int) (Math.random() * freeColumns.size()));
+                }
+                marker.layoutXProperty().bind(markerBindings[column]);
+                placePiece(column);
+                updateMarkerBindings();
             } else {
                 swapTurns();
             }

--- a/src/main/java/com/megabyte6/connect4/model/Game.java
+++ b/src/main/java/com/megabyte6/connect4/model/Game.java
@@ -4,7 +4,9 @@ import com.megabyte6.connect4.App;
 import com.megabyte6.connect4.util.tuple.Triplet;
 import com.megabyte6.connect4.util.tuple.Tuple;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 import static com.megabyte6.connect4.util.Range.range;
 
@@ -51,6 +53,18 @@ public class Game {
         }
 
         return -1;
+    }
+
+    public List<Integer> findFreeColumns() {
+        List<Integer> freeColumns = new ArrayList<>();
+
+        for (int i = 0; i < getColumnCount(); i++) {
+            if (findNextFreeRow(i) != -1) {
+                freeColumns.add(i);
+            }
+        }
+
+        return freeColumns;
     }
 
     public boolean isOutOfBounds(int columnIndex, int rowIndex) {


### PR DESCRIPTION
If the current column is full, auto-drop will random choose an open column.

Previously, if the selected column was full, the timer would just stop and stay on that persons turn. It was a game-breaking exploit that professional players were using to circumvent the timer.