### PR TITLE
Add support for Nix with Connect 4 game packaging and JavaFX dependen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,36 @@
     - Extract the files.
     - Navigate to the `bin` folder.
     - Run `connect-4` (or `connect-4.bat` if you're on Windows).
+- Nix (with flakes):
+    - To just run `connect-4`: `nix run github:megabyte6/connect-4`.
+    - To install `connect-4` at the user-level: `nix profile install github:megabyte6/connect-4`.
+    - To install `connect-4` system-wide, you can use something akin to the following example flake:
+      ```nix
+      {
+        description = "Example flake that includes connect-4 as a package";
+
+        inputs = {
+          nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+          connect4.url = "github:megabyte6/connect-4";
+        };
+
+        outputs = { self, nixpkgs, connect4, ... }:
+        let
+          system = "x86_64-linux";
+        in {
+          nixosConfigurations.myHost = nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            ({ pkgs, ... }: {
+              environment.systemPackages = [
+                connect4.packages.${system}.default
+              ];
+            })
+          ];
+          };
+        };
+      }
+      ```
 
 Note:
 
@@ -35,7 +65,7 @@ Note: This project should be built with JDK 25 but the build script will install
 
 1. Download this repository with the green `Code` button.
 1. Navigate to the project folder. You should see a `build.gradle` file.
-1. Open a terminal in this directory and run `./gradlew run` (or `gradlew.bat run` if you're on Windows Command Prompt) to run the game.
+1. Open a terminal in this directory and run `./gradlew run` (or `gradlew.bat run` on Windows) to run the game.
 
 ---
 
@@ -51,18 +81,26 @@ Note: This project should be built with JDK 25.
         1. Play it by extracting the zip and running the `connect-4` in the `bin` folder
     - Build installers & executables:
         1. Check [Oracle's website](https://docs.oracle.com/en/java/javase/14/jpackage/packaging-overview.html#GUID-786E15C0-2CE7-4BDF-9B2F-AC1C57249134:~:text=Java%20Runtime%20Requirements-,Packaging%20Pre%2DReqs,WiX%203.0%20or%20later%20is%20required.,-Application%20Preparation) for info on your system's prerequisites.
-        1. Optionally change the `jpackageFormat` option in `gradle.properties` if you want to build a different type of installer/executable. By default, it will choose a format based on your current operating system.
+        1. Optionally change the `jpackageFormat` option in `gradle.properties` if you want to build a different type of installer/executable. By default, it will choose a format based on your current operating system. Note that you can only build for the operating system you're on (e.g. you can only build a Windows installer on Windows).
         1. Run `./gradlew jpackage`
         1. Check `build/jpackage` for the installer(s) and `build/jpackage/Connect 4` for the executable(s).
+
+### Nix (flakes)
+
+Building can be done with `nix build` once the project is cloned.
+
+For NixOS users, the nix package is recommended as it has trouble finding the correct libraries when using the pre-built jlink image.
 
 ---
 
 ## Contributing
 
-Contributions are welcome! Create an issue or open a pull request!
+Contributions are welcome! [Create an issue](https://github.com/megabyte6/connect-4/issues/new/choose) or open a [pull request](https://github.com/megabyte6/connect-4/compare)! If you are interested in contributing but don't know where to start, check out the [existing issues](https://github.com/megabyte6/connect-4/issues) for some ideas.
+
+If you are on NixOS, you can use the dev shell to set up a development environment with all the necessary dependencies. To enter the dev shell, run `nix develop` in the project directory. This works well with `direnv` if you wish to use it. **If you plan to update any Gradle dependencies/plugins or similar, remember to delete `gradle.lock` and regenerate it with `nix run github:tadfisher/gradle2nix/v2 -- --task=jlinkZip` so Nix can correctly pre-download the correct versions.**
 
 Note:
-If editing on VSCode, run `./gradlew eclipse` to fix errors in `module-info.java` that occur due to a bug in the java extension.
+If editing on VSCode, run `./gradlew eclipse` to fix errors in `module-info.java` that occur due to a bug in the Java language server extension.
 
 ---
 
@@ -74,7 +112,8 @@ This project uses the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Thanks
 
-This project was possible due to the following libraries:
+This project was possible due to the following projects:
 - [JavaFX](https://openjfx.io)
 - [badass-jlink-plugin](https://github.com/beryx/badass-jlink-plugin)
 - [jackson](https://github.com/FasterXML/jackson)
+- [gradle2nix](https://github.com/tadfisher/gradle2nix)

--- a/flake.lock
+++ b/flake.lock
@@ -1,13 +1,67 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gradle2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1755902591,
+        "narHash": "sha256-mnPaPH9k6Mbr7O0KzBBdkiDDS88oB5NiFHVSFkCzswU=",
+        "owner": "tadfisher",
+        "repo": "gradle2nix",
+        "rev": "30cfe5889188524223364ee7919d94e83d6ee44a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tadfisher",
+        "ref": "v2",
+        "repo": "gradle2nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
-        "revCount": 956934,
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "revCount": 987561,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.956934%2Brev-cf59864ef8aa2e178cccedbe2c178185b0365705/019caf4e-4d68-7196-ab8f-8f2a855e40d4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.987561%2Brev-1c3fe55ad329cbcb28471bb30f05c9827f724c76/019dd544-2f5a-70b0-a89a-cf26aa85b1a7/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -16,7 +70,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "gradle2nix": "gradle2nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,39 @@
             libxtst
             libxxf86vm
           ];
+
+        # Fixed-output derivation that pre-fetches all Gradle dependencies
+        # (both build-script plugins and project dependencies) with network
+        # access.  The resulting store path is passed as GRADLE_USER_HOME in
+        # the main build so it can run fully offline.
+        #
+        # When dependencies change, update the hash by:
+        #   1. Set outputHash to lib.fakeHash below.
+        #   2. Run `nix build .#packages.<system>.default 2>&1 | grep "got:"`.
+        #   3. Replace lib.fakeHash with the printed sha256 hash.
+        offlineDeps = pkgs.stdenv.mkDerivation {
+          name = "connect-4-gradle-deps";
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [gradle jdk];
+
+          buildPhase = ''
+            export HOME="$TMPDIR"
+            export GRADLE_USER_HOME="$TMPDIR/gradle-home"
+            # buildEnvironment resolves buildscript plugin dependencies;
+            # dependencies resolves the project's runtime dependencies.
+            # No test dependencies are declared in this project.
+            gradle --no-daemon buildEnvironment dependencies
+          '';
+
+          installPhase = ''
+            cp -r "$TMPDIR/gradle-home" "$out"
+          '';
+
+          outputHashAlgo = "sha256";
+          outputHashMode = "recursive";
+          outputHash = lib.fakeHash;
+        };
       in {
         default = pkgs.stdenv.mkDerivation {
           pname = "connect-4";
@@ -66,8 +99,8 @@
             runHook preBuild
 
             export HOME="$TMPDIR"
-            export GRADLE_USER_HOME="$TMPDIR/gradle-home"
-            gradle --no-daemon clean jlinkZip
+            export GRADLE_USER_HOME="${offlineDeps}"
+            gradle --no-daemon --offline clean jlinkZip
 
             runHook postBuild
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,22 @@
 {
   description = "A Nix-flake-based Java development environment";
 
-  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+    gradle2nix.url = "github:tadfisher/gradle2nix/v2";
+  };
 
   outputs = {self, ...} @ inputs: let
     javaVersion = 25;
+
+    # JavaFX Linux runtime dependencies
+    libPathFor = pkgs:
+      pkgs.lib.makeLibraryPath [
+        pkgs.glib
+        pkgs.libGL
+        pkgs.libxtst
+        pkgs.libxxf86vm
+      ];
 
     supportedSystems = [
       "x86_64-linux"
@@ -29,7 +41,7 @@
     in {
       inherit jdk;
       maven = prev.maven.override {jdk_headless = jdk;};
-      gradle = prev.gradle.override {java = jdk;};
+      gradle = prev.gradle_9.override {java = jdk;};
       lombok = prev.lombok.override {inherit jdk;};
     };
 
@@ -37,113 +49,67 @@
       {
         pkgs,
         system,
-      }: let
-        lib = pkgs.lib;
-        isLinux = pkgs.stdenv.hostPlatform.isLinux;
-
-        javaFxLibPath = with pkgs;
-          lib.makeLibraryPath [
-            glib
-            libGL
-            libxtst
-            libxxf86vm
-          ];
-
-        # Fixed-output derivation that pre-fetches all Gradle dependencies
-        # (both build-script plugins and project dependencies) with network
-        # access.  The resulting store path is passed as GRADLE_USER_HOME in
-        # the main build so it can run fully offline.
-        #
-        # When dependencies change, update the hash by:
-        #   1. Set outputHash to lib.fakeHash below.
-        #   2. Run `nix build .#packages.<system>.default 2>&1 | grep "got:"`.
-        #   3. Replace lib.fakeHash with the printed sha256 hash.
-        offlineDeps = pkgs.stdenv.mkDerivation {
-          name = "connect-4-gradle-deps";
-          src = ./.;
-
-          nativeBuildInputs = with pkgs; [gradle jdk];
-
-          buildPhase = ''
-            export HOME="$TMPDIR"
-            export GRADLE_USER_HOME="$TMPDIR/gradle-home"
-            # buildEnvironment resolves buildscript plugin dependencies;
-            # dependencies resolves the project's runtime dependencies.
-            # No test dependencies are declared in this project.
-            gradle --no-daemon buildEnvironment dependencies
-          '';
-
-          installPhase = ''
-            cp -r "$TMPDIR/gradle-home" "$out"
-          '';
-
-          outputHashAlgo = "sha256";
-          outputHashMode = "recursive";
-          outputHash = lib.fakeHash;
-        };
-      in {
-        default = pkgs.stdenv.mkDerivation {
+      }: {
+        connect-4 = inputs.gradle2nix.builders.${system}.buildGradlePackage {
           pname = "connect-4";
           version = "2.0";
-
           src = ./.;
 
+          lockFile = ./gradle.lock;
+          gradle = pkgs.gradle;
+          buildJdk = pkgs.jdk;
+
+          gradleBuildFlags = ["jlinkZip"];
           nativeBuildInputs = with pkgs; [
-            gradle
-            jdk
             makeWrapper
             unzip
           ];
+          installPhase = let
+            libPath = libPathFor pkgs;
+          in ''
+            tmp="$(mktemp -d)"
+            unzip -q build/connect4.zip -d "$tmp"
+            if [ -d "$tmp/image" ]; then
+              mkdir -p "$out"
+              cp -a "$tmp/image/." "$out/"
 
-          buildPhase = ''
-            runHook preBuild
-
-            export HOME="$TMPDIR"
-            export GRADLE_USER_HOME="${offlineDeps}"
-            gradle --no-daemon --offline clean jlinkZip
-
-            runHook postBuild
-          '';
-
-          installPhase = ''
-            runHook preInstall
-
-            mkdir -p "$out"
-            unzip -q build/connect4.zip -d "$out"
-            appDir="$(find "$out" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
-            mkdir -p "$out/bin"
-
-            makeWrapper "$appDir/bin/connect-4" "$out/bin/connect-4" \
-              --set JAVA_HOME "${pkgs.jdk}" \
-              ${
-              if isLinux
-              then "--prefix LD_LIBRARY_PATH : ${javaFxLibPath}"
+              if [ -f "$out/bin/connect-4" ]; then
+                wrapProgram "$out/bin/connect-4" \
+                  --set JAVA_HOME "${pkgs.jdk}" \
+                  --unset JAVA_TOOL_OPTIONS \
+                  ${
+              if pkgs.stdenv.hostPlatform.isLinux
+              then "--prefix LD_LIBRARY_PATH : ${libPath}"
               else ""
             }
-
-            runHook postInstall
+              fi
+            else
+              echo "Expected 'image/' directory not found in connect4.zip" >&2
+              exit 1
+            fi
           '';
 
           meta = with pkgs.lib; {
             description = "A simple Connect 4 game implemented in JavaFX";
             homepage = "https://github.com/megabyte6/connect-4";
             license = licenses.mit;
-            platforms = supportedSystems;
             mainProgram = "connect-4";
+            platforms = supportedSystems;
           };
         };
 
-        connect-4 = self.packages.${system}.default;
+        default = self.packages.${system}.connect-4;
       }
     );
 
     apps = forEachSupportedSystem (
       {system, ...}: {
-        default = {
+        connect-4 = {
           type = "app";
           program = "${self.packages.${system}.default}/bin/connect-4";
         };
-        connect-4 = self.apps.${system}.default;
+
+        default = self.apps.${system}.connect-4;
       }
     );
 
@@ -151,16 +117,7 @@
       {
         pkgs,
         system,
-      }: let
-        # JavaFX Linux runtime dependencies
-        javaFxLibPath = with pkgs;
-          lib.makeLibraryPath [
-            glib
-            libGL
-            libxtst
-            libxxf86vm
-          ];
-      in {
+      }: {
         default = pkgs.mkShellNoCC {
           packages = with pkgs; [
             gcc
@@ -176,11 +133,12 @@
           shellHook = let
             loadLombok = "-javaagent:${pkgs.lombok}/share/java/lombok.jar";
             prev = "\${JAVA_TOOL_OPTIONS:+ $JAVA_TOOL_OPTIONS}";
+            libPath = libPathFor pkgs;
           in ''
             export PATH="${pkgs.jdk}/bin:$PATH"
             export JAVA_HOME="${pkgs.jdk}"
             export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
-            export LD_LIBRARY_PATH="${javaFxLibPath}:''${LD_LIBRARY_PATH:-}"
+            export LD_LIBRARY_PATH="${libPath}:''${LD_LIBRARY_PATH:-}"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,100 @@
       lombok = prev.lombok.override {inherit jdk;};
     };
 
+    packages = forEachSupportedSystem (
+      {
+        pkgs,
+        system,
+      }: let
+        lib = pkgs.lib;
+        isLinux = pkgs.stdenv.hostPlatform.isLinux;
+
+        javaFxLibPath = with pkgs;
+          lib.makeLibraryPath [
+            glib
+            libGL
+            libxtst
+            libxxf86vm
+          ];
+      in {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "connect-4";
+          version = "2.0";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            gradle
+            jdk
+            makeWrapper
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            export HOME="$TMPDIR"
+            export GRADLE_USER_HOME="$TMPDIR/gradle-home"
+            gradle --no-daemon clean jlinkZip
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out"
+            unzip -q build/connect-4.zip -d "$out"
+            appDir="$(find "$out" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+            mkdir -p "$out/bin"
+
+            makeWrapper "$appDir/bin/connect-4" "$out/bin/connect-4" \
+              --set JAVA_HOME "${pkgs.jdk}" \
+              ${
+              if isLinux
+              then "--prefix LD_LIBRARY_PATH : ${javaFxLibPath}"
+              else ""
+            }
+
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "A simple Connect 4 game implemented in JavaFX";
+            homepage = "https://github.com/megabyte6/connect-4";
+            license = licenses.mit;
+            platforms = supportedSystems;
+            mainProgram = "connect-4";
+          };
+        };
+
+        connect-4 = self.packages.${system}.default;
+      }
+    );
+
+    apps = forEachSupportedSystem (
+      {system, ...}: {
+        default = {
+          type = "app";
+          program = "${self.devShells.${system}.bin}/bin/connect-4";
+        };
+        connect-4 = self.apps.${system}.default;
+      }
+    );
+
     devShells = forEachSupportedSystem (
       {
         pkgs,
         system,
-      }: {
+      }: let
+        # JavaFX Linux runtime dependencies
+        javaFxLibPath = with pkgs;
+          lib.makeLibraryPath [
+            glib
+            libGL
+            libxtst
+            libxxf86vm
+          ];
+      in {
         default = pkgs.mkShellNoCC {
           packages = with pkgs; [
             gcc
@@ -53,19 +142,11 @@
           shellHook = let
             loadLombok = "-javaagent:${pkgs.lombok}/share/java/lombok.jar";
             prev = "\${JAVA_TOOL_OPTIONS:+ $JAVA_TOOL_OPTIONS}";
-
-            # JavaFX Linux runtime dependencies
-            libPath = with pkgs; lib.makeLibraryPath [
-              glib
-              libGL
-              libxtst
-              libxxf86vm
-            ];
           in ''
             export PATH="${pkgs.jdk}/bin:$PATH"
             export JAVA_HOME="${pkgs.jdk}"
             export JAVA_TOOL_OPTIONS="${loadLombok}${prev}"
-            export LD_LIBRARY_PATH="${libPath}:''${LD_LIBRARY_PATH:-}"
+            export LD_LIBRARY_PATH="${javaFxLibPath}:''${LD_LIBRARY_PATH:-}"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
             gradle
             jdk
             makeWrapper
+            unzip
           ];
 
           buildPhase = ''
@@ -75,7 +76,7 @@
             runHook preInstall
 
             mkdir -p "$out"
-            unzip -q build/connect-4.zip -d "$out"
+            unzip -q build/connect4.zip -d "$out"
             appDir="$(find "$out" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
             mkdir -p "$out/bin"
 
@@ -107,7 +108,7 @@
       {system, ...}: {
         default = {
           type = "app";
-          program = "${self.devShells.${system}.bin}/bin/connect-4";
+          program = "${self.packages.${system}.default}/bin/connect-4";
         };
         connect-4 = self.apps.${system}.default;
       }

--- a/gradle.lock
+++ b/gradle.lock
@@ -1,0 +1,256 @@
+{
+  "com.fasterxml:oss-parent:75": {
+    "oss-parent-75.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/75/oss-parent-75.pom",
+      "hash": "sha256-/LvxwYyQR+aRfThPIGTiG0Klj8hfsFI6ni4BXv98YZ0="
+    }
+  },
+  "com.fasterxml.jackson:jackson-base:2.21.2": {
+    "jackson-base-2.21.2.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.21.2/jackson-base-2.21.2.pom",
+      "hash": "sha256-OMeJjHY7iZH/+9dpRZly4Bdr8MUFxzlRjHD3xX0W7tc="
+    }
+  },
+  "com.fasterxml.jackson:jackson-bom:2.21.2": {
+    "jackson-bom-2.21.2.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.21.2/jackson-bom-2.21.2.pom",
+      "hash": "sha256-vGxUnmMpJ7udigraIMhGe1AH07eXx/XbA6m2DR3lm+M="
+    }
+  },
+  "com.fasterxml.jackson:jackson-parent:2.21": {
+    "jackson-parent-2.21.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.21/jackson-parent-2.21.pom",
+      "hash": "sha256-OFHfYn+utGiHuVYQRjC3Sou7X33iLpdM8VmC4g4Dc94="
+    }
+  },
+  "com.fasterxml.jackson.core:jackson-annotations:2.21": {
+    "jackson-annotations-2.21.jar": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar",
+      "hash": "sha256-U8oIX0oVD3A/SeGqvZNb0DtD4eo9VdE1Q4KSryLO9Ws="
+    },
+    "jackson-annotations-2.21.module": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.module",
+      "hash": "sha256-yuj/7OwzKLbsuxOOJ0IY8v4cdymg6CTaVZJogQCVrUQ="
+    },
+    "jackson-annotations-2.21.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.pom",
+      "hash": "sha256-ccrFOSFR4qUozJoJF58KM0F58FxS+OWWz1jd8Suyfys="
+    }
+  },
+  "com.fasterxml.jackson.core:jackson-core:2.21.2": {
+    "jackson-core-2.21.2.jar": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.2/jackson-core-2.21.2.jar",
+      "hash": "sha256-EuhlWxACZ7RNDxTQGx9QgqUQXmFhdNxDB74adh6SQHs="
+    },
+    "jackson-core-2.21.2.module": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.2/jackson-core-2.21.2.module",
+      "hash": "sha256-mO7k69IcgrUmtDiIjgOta245Zvxucizk433UWQ0+Sic="
+    },
+    "jackson-core-2.21.2.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.2/jackson-core-2.21.2.pom",
+      "hash": "sha256-urDlWZZJzLWrIanPnS5XGS3h5I5tI1JNwlPWL8c8ljQ="
+    }
+  },
+  "com.fasterxml.jackson.core:jackson-databind:2.21.2": {
+    "jackson-databind-2.21.2.jar": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.2/jackson-databind-2.21.2.jar",
+      "hash": "sha256-jJgvAfFI2AXwqqwjOQESRHV+DffG/4lR8vo/QzuO2Ek="
+    },
+    "jackson-databind-2.21.2.module": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.2/jackson-databind-2.21.2.module",
+      "hash": "sha256-qODdfyv9PgmoyLc0nGEFb96cuGL4ZOvG8jGT5fYIXzg="
+    },
+    "jackson-databind-2.21.2.pom": {
+      "url": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.21.2/jackson-databind-2.21.2.pom",
+      "hash": "sha256-z44OzcNfAtoG4n9BV2ALqddknFJy5Na3le8qQvBwomI="
+    }
+  },
+  "com.google.code.findbugs:jsr305:3.0.2": {
+    "jsr305-3.0.2.jar": {
+      "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+      "hash": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc="
+    },
+    "jsr305-3.0.2.pom": {
+      "url": "https://plugins.gradle.org/m2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom",
+      "hash": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+    }
+  },
+  "com.google.gradle:osdetector-gradle-plugin:1.7.3": {
+    "osdetector-gradle-plugin-1.7.3.jar": {
+      "url": "https://plugins.gradle.org/m2/com/google/gradle/osdetector-gradle-plugin/1.7.3/osdetector-gradle-plugin-1.7.3.jar",
+      "hash": "sha256-a0aS+ROiGx+2Axae54uo8+SrKvnXYq+cqIt5EmwcCtE="
+    },
+    "osdetector-gradle-plugin-1.7.3.pom": {
+      "url": "https://plugins.gradle.org/m2/com/google/gradle/osdetector-gradle-plugin/1.7.3/osdetector-gradle-plugin-1.7.3.pom",
+      "hash": "sha256-hGDJUBJ8o1mHZhYeOLT/jWO01p+4MQoW4As1E1ABDBE="
+    }
+  },
+  "io.freefair.gradle:lombok-plugin:9.4.0": {
+    "lombok-plugin-9.4.0.jar": {
+      "url": "https://plugins.gradle.org/m2/io/freefair/gradle/lombok-plugin/9.4.0/lombok-plugin-9.4.0.jar",
+      "hash": "sha256-xY3bl72cusvV/tE9Cv8F6LxZV93tDrv9sGZe1WPz5Gc="
+    },
+    "lombok-plugin-9.4.0.module": {
+      "url": "https://plugins.gradle.org/m2/io/freefair/gradle/lombok-plugin/9.4.0/lombok-plugin-9.4.0.module",
+      "hash": "sha256-EmNMiSMLYD8YGkTW/sNmXzpqSE5ROBN/iVeAP+a8pKY="
+    },
+    "lombok-plugin-9.4.0.pom": {
+      "url": "https://plugins.gradle.org/m2/io/freefair/gradle/lombok-plugin/9.4.0/lombok-plugin-9.4.0.pom",
+      "hash": "sha256-gbOqgm2a6bjLDwfJZAwT0X9tFroPI/ZvswAGQvdpe6g="
+    }
+  },
+  "io.freefair.lombok:io.freefair.lombok.gradle.plugin:9.4.0": {
+    "io.freefair.lombok.gradle.plugin-9.4.0.pom": {
+      "url": "https://plugins.gradle.org/m2/io/freefair/lombok/io.freefair.lombok.gradle.plugin/9.4.0/io.freefair.lombok.gradle.plugin-9.4.0.pom",
+      "hash": "sha256-o1zojz/INIQu2AZjMxchWdqDeDNXBeI8KzrnrxbcM4I="
+    }
+  },
+  "kr.motd.maven:os-maven-plugin:1.7.1": {
+    "os-maven-plugin-1.7.1.jar": {
+      "url": "https://plugins.gradle.org/m2/kr/motd/maven/os-maven-plugin/1.7.1/os-maven-plugin-1.7.1.jar",
+      "hash": "sha256-9Hru+Ggh5SsrGHWJeL0EXwPXIikuMudHCCEixiKJUuA="
+    },
+    "os-maven-plugin-1.7.1.pom": {
+      "url": "https://plugins.gradle.org/m2/kr/motd/maven/os-maven-plugin/1.7.1/os-maven-plugin-1.7.1.pom",
+      "hash": "sha256-S3WABEIrljPdMY8p54Tx0YC9ilkgzVCvGTCGH21qVHY="
+    }
+  },
+  "org.beryx:badass-jlink-plugin:3.2.1": {
+    "badass-jlink-plugin-3.2.1.jar": {
+      "url": "https://plugins.gradle.org/m2/org/beryx/badass-jlink-plugin/3.2.1/badass-jlink-plugin-3.2.1.jar",
+      "hash": "sha256-bArtr/xRR7/gMI1+Ksn6ZEK5odgieegguqq2Rp6d6kk="
+    },
+    "badass-jlink-plugin-3.2.1.module": {
+      "url": "https://plugins.gradle.org/m2/org/beryx/badass-jlink-plugin/3.2.1/badass-jlink-plugin-3.2.1.module",
+      "hash": "sha256-yNTtqq9WRSq++JTsxFNaebz01nWbe0ei8KwyoeTR6A4="
+    },
+    "badass-jlink-plugin-3.2.1.pom": {
+      "url": "https://plugins.gradle.org/m2/org/beryx/badass-jlink-plugin/3.2.1/badass-jlink-plugin-3.2.1.pom",
+      "hash": "sha256-AP5U4mGl7w2XTqOnuYgoyV9WOQJpM/P4h4MaATceAmM="
+    }
+  },
+  "org.beryx.jlink:org.beryx.jlink.gradle.plugin:3.2.1": {
+    "org.beryx.jlink.gradle.plugin-3.2.1.pom": {
+      "url": "https://plugins.gradle.org/m2/org/beryx/jlink/org.beryx.jlink.gradle.plugin/3.2.1/org.beryx.jlink.gradle.plugin-3.2.1.pom",
+      "hash": "sha256-WDsyl9x6uWkPafqKlLlTVha8fdmBrlhW0TzdzeTNjKQ="
+    }
+  },
+  "org.gradle.toolchains:foojay-resolver:1.0.0": {
+    "foojay-resolver-1.0.0.jar": {
+      "url": "https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver/1.0.0/foojay-resolver-1.0.0.jar",
+      "hash": "sha256-eLhqR9/fdpfJvRXaeJg/2A2nJH1uAvwQa98H4DiLYKg="
+    },
+    "foojay-resolver-1.0.0.module": {
+      "url": "https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver/1.0.0/foojay-resolver-1.0.0.module",
+      "hash": "sha256-YZDPDkLmZMEeGsCnhWmasCtUnOo0OSxnnzbYosVQ/Lk="
+    },
+    "foojay-resolver-1.0.0.pom": {
+      "url": "https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver/1.0.0/foojay-resolver-1.0.0.pom",
+      "hash": "sha256-m8SLSeQi2e2rw5asGNiwQd/CIhLX+ujjVmfShdSBApo="
+    }
+  },
+  "org.gradle.toolchains.foojay-resolver-convention:org.gradle.toolchains.foojay-resolver-convention.gradle.plugin:1.0.0": {
+    "org.gradle.toolchains.foojay-resolver-convention.gradle.plugin-1.0.0.pom": {
+      "url": "https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver-convention/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin/1.0.0/org.gradle.toolchains.foojay-resolver-convention.gradle.plugin-1.0.0.pom",
+      "hash": "sha256-8TMkmhh1Suah0nAdANhJsa+6ewaD3bX8GxinAHHOwvo="
+    }
+  },
+  "org.junit:junit-bom:5.14.1": {
+    "junit-bom-5.14.1.module": {
+      "url": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.14.1/junit-bom-5.14.1.module",
+      "hash": "sha256-J4rLEczJmYaUIkOG+W+0lBoi7bQstEbJLg8fMwFLa0g="
+    },
+    "junit-bom-5.14.1.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.14.1/junit-bom-5.14.1.pom",
+      "hash": "sha256-AbAd+jZlULQKxXYFSKfXKLYQnRfEUeg4ZNHl4M6GLJQ="
+    }
+  },
+  "org.openjfx:javafx:25": {
+    "javafx-25.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx/25/javafx-25.pom",
+      "hash": "sha256-55IzCPyt1/LGiwcgQfR9jnNVIj2EZVnutceA3EuivxM="
+    }
+  },
+  "org.openjfx:javafx-base:25": {
+    "javafx-base-25-linux.jar": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/25/javafx-base-25-linux.jar",
+      "hash": "sha256-MkJZRruLjbBxfPovsuAOIc1InzW5ZitvrKGLYVpKlmk="
+    },
+    "javafx-base-25.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/25/javafx-base-25.pom",
+      "hash": "sha256-XFYpcqK673qkB7J9Wc4XOl6lCht7dRgEO3/I92/v5Tc="
+    }
+  },
+  "org.openjfx:javafx-controls:25": {
+    "javafx-controls-25-linux.jar": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/25/javafx-controls-25-linux.jar",
+      "hash": "sha256-NzVeTZHGfoj9mBX2AeasW1Xd3p9em5P8j0qgRXfmkdM="
+    },
+    "javafx-controls-25.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-controls/25/javafx-controls-25.pom",
+      "hash": "sha256-74cad6gX7nuDrKWKKe6yv5h2AvRseKHRXEYAgzpq1uM="
+    }
+  },
+  "org.openjfx:javafx-fxml:25": {
+    "javafx-fxml-25-linux.jar": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/25/javafx-fxml-25-linux.jar",
+      "hash": "sha256-OUrjL2TBIsFPvRDvSb3efbsFVpt6uOf58XDIGSS5Wis="
+    },
+    "javafx-fxml-25.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-fxml/25/javafx-fxml-25.pom",
+      "hash": "sha256-RopsFNQeVHnwNK4v4FPwyJEpfqJoo8dtf/047zyrsio="
+    }
+  },
+  "org.openjfx:javafx-graphics:25": {
+    "javafx-graphics-25-linux.jar": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/25/javafx-graphics-25-linux.jar",
+      "hash": "sha256-PlGLwX7lWFWaKsWKX3/UUmFRCNnVCI9lsTvuk5nDcis="
+    },
+    "javafx-graphics-25.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/openjfx/javafx-graphics/25/javafx-graphics-25.pom",
+      "hash": "sha256-zB2jY7Id7uvymRWBk9qmIB+USw+Setv13DhL62qDOfQ="
+    }
+  },
+  "org.openjfx:javafx-plugin:0.1.0": {
+    "javafx-plugin-0.1.0.jar": {
+      "url": "https://plugins.gradle.org/m2/org/openjfx/javafx-plugin/0.1.0/javafx-plugin-0.1.0.jar",
+      "hash": "sha256-Xq7sB5m0QGRrDKTP2iGaMttr4rpXktAyoNpKOlw4j6s="
+    },
+    "javafx-plugin-0.1.0.module": {
+      "url": "https://plugins.gradle.org/m2/org/openjfx/javafx-plugin/0.1.0/javafx-plugin-0.1.0.module",
+      "hash": "sha256-rf+3RA0kntF8BJOD1nBp+UU7F3gncMAFtoKkNBbYNmE="
+    },
+    "javafx-plugin-0.1.0.pom": {
+      "url": "https://plugins.gradle.org/m2/org/openjfx/javafx-plugin/0.1.0/javafx-plugin-0.1.0.pom",
+      "hash": "sha256-NMjfVSfrWjXl8AmjzeH3oInEzkoOclgC8uy+UDu9PLY="
+    }
+  },
+  "org.openjfx.javafxplugin:org.openjfx.javafxplugin.gradle.plugin:0.1.0": {
+    "org.openjfx.javafxplugin.gradle.plugin-0.1.0.pom": {
+      "url": "https://plugins.gradle.org/m2/org/openjfx/javafxplugin/org.openjfx.javafxplugin.gradle.plugin/0.1.0/org.openjfx.javafxplugin.gradle.plugin-0.1.0.pom",
+      "hash": "sha256-1tASf/Q2PQAXPDV6mByec+/wPDCl0Ohq2CtgVPrvqEE="
+    }
+  },
+  "org.projectlombok:lombok:1.18.44": {
+    "lombok-1.18.44.jar": {
+      "url": "https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.44/lombok-1.18.44.jar",
+      "hash": "sha256-xukb/cNYux77Je4YXpWq+bYABD5fgdA712rvwBA1v4Y="
+    },
+    "lombok-1.18.44.pom": {
+      "url": "https://repo.maven.apache.org/maven2/org/projectlombok/lombok/1.18.44/lombok-1.18.44.pom",
+      "hash": "sha256-OVHse72PKj1jcndGuCxzpU0+xEqe4l/8L2PGmW6eUGo="
+    }
+  },
+  "org.sonatype.oss:oss-parent:9": {
+    "oss-parent-9.pom": {
+      "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/9/oss-parent-9.pom",
+      "hash": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+    }
+  },
+  "org.sonatype.oss:oss-parent:7": {
+    "oss-parent-7.pom": {
+      "url": "https://plugins.gradle.org/m2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+      "hash": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a Nix packaging setup for the Connect-4 JavaFX application, making it easier to build, install, and run the app across supported systems. The main focus is on adding a reproducible package and application definition, along with improvements to the development shell environment.

**Packaging and distribution:**

* Added a `packages` attribute using `forEachSupportedSystem` to build a Nix package for Connect-4, including a build process with Gradle, proper JavaFX runtime dependencies, and a wrapped executable for easier launching.
* Defined an `apps` attribute to allow running the packaged application via Nix's app interface, referencing the built binary.

**Development environment improvements:**

* Updated the `devShells` attribute to ensure the development shell includes the necessary JavaFX runtime dependencies in `LD_LIBRARY_PATH` for Linux, improving out-of-the-box compatibility. [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R36-R129) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L56-R149)
* Refactored the shell hook to use the shared JavaFX library path variable, simplifying maintenance and reducing duplication.